### PR TITLE
Add option to hide tags that are marked as spoilers

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -36,6 +36,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
             AniDbRateLimit = 2000;
             AniDbReplaceGraves = true;
+            AniListShowSpoilerTags = true;
         }
 
         public TitlePreferenceType TitlePreference { get; set; }
@@ -51,5 +52,6 @@ namespace Jellyfin.Plugin.AniList.Configuration
         public int AniDbRateLimit { get; set; }
 
         public bool AniDbReplaceGraves { get; set; }
+        public bool AniListShowSpoilerTags { get; set; }
     }
 }

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -54,6 +54,12 @@
                                 <span>AniDB Replace Grave Characters</span>
                             </label>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkAniListShowSpoilerTags" name="chkAniListShowSpoilerTags" type="checkbox" is="emby-checkbox" />
+                                <span>Display Tags that are marked as spoilers</span>
+                            </label>
+                        </div>
                         <div>
                             <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                                 <span>Save</span>
@@ -78,6 +84,7 @@
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
                             document.getElementById('chkAniDbReplaceGraves').checked = config.AniDbReplaceGraves;
+                            document.getElementById('chkAniListShowSpoilerTags').checked = config.AniListShowSpoilerTags;
 
                             Dashboard.hideLoadingMsg();
                         });
@@ -94,6 +101,7 @@
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;
+                            config.AniListShowSpoilerTags = document.getElementById('chkAniListShowSpoilerTags').checked;
 
                             ApiClient.updatePluginConfiguration(AniListConfigurationPage.pluginUniqueId, config).then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -87,6 +87,7 @@ query($id: Int!, $type: MediaType) {
       id
       name
       category
+      isMediaSpoiler
     }
     nextAiringEpisode {
       airingAt

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -335,6 +335,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         public string name { get; set; }
         public string description { get; set; }
         public string category { get; set; }
+        public bool isMediaSpoiler { get; set; }
     }
 
     public class Studio

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -213,9 +213,11 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         /// <returns></returns>
         public List<string> GetTagNames()
         {
+            PluginConfiguration config = Plugin.Instance.Configuration;
             List<string> results = new List<string>();
             foreach (Tag tag in this.tags)
             {
+                if (!config.AniListShowSpoilerTags && tag.isMediaSpoiler) continue;
                 results.Add(tag.name);
             }
             return results;

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using MediaBrowser.Model.Providers;
 using MediaBrowser.Model.Entities;
@@ -214,13 +215,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         public List<string> GetTagNames()
         {
             PluginConfiguration config = Plugin.Instance.Configuration;
-            List<string> results = new List<string>();
-            foreach (Tag tag in this.tags)
-            {
-                if (!config.AniListShowSpoilerTags && tag.isMediaSpoiler) continue;
-                results.Add(tag.name);
-            }
-            return results;
+            return (from tag in this.tags where config.AniListShowSpoilerTags || !tag.isMediaSpoiler select tag.name).ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
AniList has an option to classify tags as spoilers, and I've added an option to hide these tags so you don't accidentally get spoiled.
The option to hide is disabled by default, but can be enabled from the plugin configuration if the user pleases.