### PR TITLE
Fix Genre settings

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -32,7 +32,6 @@ namespace Jellyfin.Plugin.AniList.Configuration
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
             MaxGenres = 5;
-            TidyGenreList = true;
             TitleCaseGenres = false;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
             AniDbRateLimit = 2000;
@@ -45,8 +44,6 @@ namespace Jellyfin.Plugin.AniList.Configuration
         public TitlePreferenceType OriginalTitlePreference { get; set; }
 
         public int MaxGenres { get; set; }
-
-        public bool TidyGenreList { get; set; }
 
         public bool TitleCaseGenres { get; set; }
 

--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -32,7 +32,6 @@ namespace Jellyfin.Plugin.AniList.Configuration
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
             MaxGenres = 5;
-            TitleCaseGenres = false;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
             AniDbRateLimit = 2000;
             AniDbReplaceGraves = true;
@@ -44,8 +43,6 @@ namespace Jellyfin.Plugin.AniList.Configuration
         public TitlePreferenceType OriginalTitlePreference { get; set; }
 
         public int MaxGenres { get; set; }
-
-        public bool TitleCaseGenres { get; set; }
 
         public AnimeDefaultGenreType AnimeDefaultGenre { get; set; }
 

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -43,12 +43,6 @@
                                 <span>Title Case Genres</span>
                             </label>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input id="chkTidyGenres" name="chkTidyGenres" type="checkbox" is="emby-checkbox" />
-                                <span>Tidy Genre List</span>
-                            </label>
-                        </div>
                         <div class="selectContainer">
                             <label class="selectLabel" for="animeDefaultGenre">Anime Default Genre Name</label>
                             <select is="emby-select" id="animeDefaultGenre" name="animeDefaultGenre" class="emby-select-withcolor emby-select">
@@ -96,7 +90,6 @@
                             document.getElementById('chkFilterPeopleByTitlePreference').checked = config.FilterPeopleByTitlePreference;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('chkTitleCaseGenres').checked = config.TitleCaseGenres;
-                            document.getElementById('chkTidyGenres').checked = config.TidyGenreList;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
                             document.getElementById('chkAniDbReplaceGraves').checked = config.AniDbReplaceGraves;
@@ -115,7 +108,6 @@
                             config.FilterPeopleByTitlePreference = document.getElementById('chkFilterPeopleByTitlePreference').checked;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.TitleCaseGenres = document.getElementById('chkTitleCaseGenres').checked;
-                            config.TidyGenreList = document.getElementById('chkTidyGenres').checked;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -37,12 +37,6 @@
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">Set this to zero to remove any limit.</div>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input id="chkTitleCaseGenres" name="chkTitleCaseGenres" type="checkbox" is="emby-checkbox" />
-                                <span>Title Case Genres</span>
-                            </label>
-                        </div>
                         <div class="selectContainer">
                             <label class="selectLabel" for="animeDefaultGenre">Anime Default Genre Name</label>
                             <select is="emby-select" id="animeDefaultGenre" name="animeDefaultGenre" class="emby-select-withcolor emby-select">
@@ -89,7 +83,6 @@
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('chkFilterPeopleByTitlePreference').checked = config.FilterPeopleByTitlePreference;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
-                            document.getElementById('chkTitleCaseGenres').checked = config.TitleCaseGenres;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
                             document.getElementById('chkAniDbReplaceGraves').checked = config.AniDbReplaceGraves;
@@ -107,7 +100,6 @@
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.FilterPeopleByTitlePreference = document.getElementById('chkFilterPeopleByTitlePreference').checked;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
-                            config.TitleCaseGenres = document.getElementById('chkTitleCaseGenres').checked;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -236,11 +236,6 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         {
             PluginConfiguration config = Plugin.Instance.Configuration;
 
-            if (config.TitleCaseGenres)
-            {
-                this.genres = this.genres.Select(g => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(g)).ToList();
-            }
-
             if (config.AnimeDefaultGenre != AnimeDefaultGenreType.None)
             {
                 this.genres = this.genres

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -1,5 +1,6 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using MediaBrowser.Model.Providers;
@@ -228,6 +229,35 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         }
 
         /// <summary>
+        /// Returns a list of genres
+        /// </summary>
+        /// <returns></returns>
+        public List<string> GetGenres()
+        {
+            PluginConfiguration config = Plugin.Instance.Configuration;
+
+            if (config.TitleCaseGenres)
+            {
+                this.genres = this.genres.Select(g => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(g)).ToList();
+            }
+
+            if (config.AnimeDefaultGenre != AnimeDefaultGenreType.None)
+            {
+                this.genres = this.genres
+                    .Except(new[] { "Animation", "Anime" })
+                    .Prepend(config.AnimeDefaultGenre.ToString())
+                    .ToList();
+            }
+
+            if (config.MaxGenres > 0)
+            {
+                this.genres = this.genres.Take(config.MaxGenres).ToList();
+            }
+
+            return this.genres.OrderBy(i => i).ToList();
+        }
+
+        /// <summary>
         /// Convert a Media object to a Series
         /// </summary>
         /// <returns></returns>
@@ -243,7 +273,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 EndDate = this.GetStartDate(),
                 CommunityRating = this.GetRating(),
                 RunTimeTicks = this.duration.HasValue ? TimeSpan.FromMinutes(this.duration.Value).Ticks : (long?)null,
-                Genres = this.genres.ToArray(),
+                Genres = this.GetGenres().ToArray(),
                 Tags = this.GetTagNames().ToArray(),
                 Studios = this.GetStudioNames().ToArray(),
                 ProviderIds = new Dictionary<string, string>() {{ProviderNames.AniList, this.id.ToString()}}


### PR DESCRIPTION
Fixes **Max Genres** setting
Fixes **Title Case Genres** setting
Fixes **Anime Default Genre** setting
Removes **Tidy Genres** setting due to redundancy

This was originally part of GenreHelper.cs which was removed when the Anime plugin was split into separate providers.

Fixes #13 