### PR TITLE
ci: set ABI version and more repo automation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# With more recent updates Visual Studio 2017 supports EditorConfig files out of the box
+# Visual Studio Code needs an extension: https://github.com/editorconfig/editorconfig-vscode
+# For emacs, vim, np++ and other editors, see here: https://github.com/editorconfig
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+max_line_length = 9999
+
+# YAML indentation
+[*.{yml,yaml}]
+indent_size = 2
+
+# XML indentation
+[*.{csproj,xml}]
+indent_size = 2

--- a/.github/workflows/command-dispatch.yaml
+++ b/.github/workflows/command-dispatch.yaml
@@ -1,0 +1,21 @@
+# Allows for the definition of PR and Issue /commands
+name: Slash Command Dispatcher
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  launcher:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.JF_BOT_TOKEN }}
+          permission: write
+          issue-type: pull-request
+          commands: |-
+            rebase
+            update-prep

--- a/.github/workflows/command-rebase.yaml
+++ b/.github/workflows/command-rebase.yaml
@@ -1,0 +1,34 @@
+name: PR Rebase Command
+
+on:
+  repository_dispatch:
+    types:
+      - rebase-command
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rebase PR
+        uses: peter-evans/rebase@v1
+        id: rebase
+        with:
+          head: ${{ github.event.client_payload.pull_request.head.label }}
+
+      - name: Add Success Reaction
+        if: ${{ steps.rebase.outputs.rebased-count == 1 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.JF_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray
+
+      - name: Add Failure Reaction
+        if: ${{ steps.rebase.outputs.rebased-count == 0 || failure() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.JF_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: confused, -1

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -1,17 +1,22 @@
 # Automates creation of Release Drafts using Release Drafter
-name: Update Release Draft
+name: Update Release Draft & Create Release Bump PR
 
 on:
   push:
     branches:
       - master
+    paths-ignore:
+      - build.yaml
   workflow_dispatch:
+  repository_dispatch:
+    types:
+      - update-prep-command
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     if: github.repository == 'jellyfin/jellyfin-plugin-anilist'
-    
+
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Update Draft
@@ -19,13 +24,13 @@ jobs:
         id: draft
         env:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
-      
+
       - name: Setup YQ
         uses: chrisdickinson/setup-yq@latest
         with:
-          yq-version: v4.9.6
+          yq-version: v4.12.2
 
-      - name: Parse changelog
+      - name: Set-up Environment
         run: |
           TAG="${{ steps.draft.outputs.tag_name }}"
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
@@ -41,16 +46,22 @@ jobs:
           cat cl.md >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
+          echo "HAS_CHANGES=$(grep -qie 'No changes$' cl.md && echo false || echo true)" >> $GITHUB_ENV
           rm cl.md
 
-      - name: Checkout repository
+          echo "ABI_VERSION=$(curl -s https://api.jellyfin.org/openapi/jellyfin-openapi-stable.json | jq -r '.info.version').0" >> $GITHUB_ENV
+
+      - name: Checkout Repository
+        if: ${{ env.HAS_CHANGES == 'true' }}
         uses: actions/checkout@v2
 
       - name: Update build.yaml
+        if: ${{ env.HAS_CHANGES == 'true' }}
         run: |
-          yq eval '.version = env(VERSION) | .changelog = strenv(CHANGELOG) | .changelog style="literal"' -i build.yaml
+          yq eval '.version = env(VERSION) | .targetAbi = env(ABI_VERSION) | .changelog = strenv(CHANGELOG) | .changelog style="literal"' -i build.yaml
 
       - name: Commit Changes
+        if: ${{ env.HAS_CHANGES == 'true' }}
         run: |
           git config user.name "jellyfin-bot"
           git config user.email "team@jellyfin.org"
@@ -59,6 +70,7 @@ jobs:
           git push -f origin prepare-${{ env.VERSION }}
 
       - name: Create or Update PR
+        if: ${{ env.HAS_CHANGES == 'true' }}
         uses: k3rnels-actions/pr-update@v1
         with:
           token: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
### Description

This PR aims to improve the plugin CI and prevent further situations where plugin update on servers that don't have the correct ABI version.

### Changes

* add Slash Command Dispatcher workflow
* add slash-rebase command workflow `/rebase`
* add release-draft update command `/update-prep`
* add ABI version update to release-drafter workflow 
* fix release-drafter workflow running after merging the prepare PR

### Issues

* n/a
* blatant copy of the webhook ci update (cause I was bothered discovering this plugin had no .editorconf :laughing: )