### PR TITLE
Change banner to backdrop

### DIFF
--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListImageProvider.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListImageProvider.cs
@@ -29,7 +29,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
 
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
         {
-            return new[] { ImageType.Primary, ImageType.Banner };
+            return new[] { ImageType.Primary, ImageType.Backdrop };
         }
 
         public Task<IEnumerable<RemoteImageInfo>> GetImages(BaseItem item, CancellationToken cancellationToken)
@@ -62,7 +62,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                         list.Add(new RemoteImageInfo
                         {
                             ProviderName = Name,
-                            Type = ImageType.Banner,
+                            Type = ImageType.Backdrop,
                             Url = media.bannerImage
                         });
                     }


### PR DESCRIPTION
The banner image from AniList isn't really suited to be used as a banner in Jellyfin. This PR changes it to a Jellyfin backdrop.

FR: https://features.jellyfin.org/posts/1930/change-anilist-plugin