### PR TITLE
Filter out non-japanese VAs for romaji titles

### DIFF
--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -199,7 +199,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 foreach (VoiceActor va in edge.voiceActors)
                 {
                     if (config.FilterPeopleByTitlePreference) {
-                        if (config.TitlePreference == TitlePreferenceType.Japanese && va.language != "JAPANESE") {
+                        if (config.TitlePreference != TitlePreferenceType.Localized && va.language != "JAPANESE") {
                             continue;
                         }
                         if (config.TitlePreference == TitlePreferenceType.Localized && va.language == "JAPANESE") {


### PR DESCRIPTION
Currently the "Filter People by Title Preference" option only filters non-Japanese voice actors IF the title language is set to Japanese. Changed it so that romaji titles also filter out non-Japanese voice actors as expected.