### PR TITLE
Limit amount of people in metadata search result

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
  - [hawken93](https://github.com/hawken93)
  - [dkanada](https://github.com/dkanada)
  - [StillLoading](https://github.com/StillLoading)
+ - [AkaTenshi](https://github.com/AkaTenshi)
 
 # Emby Contributors
 

--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -31,6 +31,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
         {
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
+            MaxPeople = 0;
             MaxGenres = 5;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
             AniDbRateLimit = 2000;
@@ -43,6 +44,8 @@ namespace Jellyfin.Plugin.AniList.Configuration
 
         public TitlePreferenceType OriginalTitlePreference { get; set; }
 
+        public int MaxPeople { get; set; }
+        
         public int MaxGenres { get; set; }
 
         public AnimeDefaultGenreType AnimeDefaultGenre { get; set; }

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -33,6 +33,11 @@
                             </label>
                         </div>
                         <div class="inputContainer">
+                            <label class="inputeLabel inputLabelUnfocused" for="chkMaxPeople">Max People</label>
+                            <input id="chkMaxPeople" name="chkMaxPeople" type="number" is="emby-input" min="0" />
+                            <div class="fieldDescription">Set this to zero to remove any limit.</div>
+                        </div>
+                        <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">Set this to zero to remove any limit.</div>
@@ -88,6 +93,7 @@
                             document.getElementById('titleLanguage').value = config.TitlePreference;
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('chkFilterPeopleByTitlePreference').checked = config.FilterPeopleByTitlePreference;
+                            document.getElementById('chkMaxPeople').value = config.MaxPeople;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
@@ -106,6 +112,7 @@
                             config.TitlePreference = document.getElementById('titleLanguage').value;
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.FilterPeopleByTitlePreference = document.getElementById('chkFilterPeopleByTitlePreference').checked;
+                            config.MaxPeople = document.getElementById('chkMaxPeople').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -273,7 +273,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 Studios = this.GetStudioNames().ToArray(),
                 ProviderIds = new Dictionary<string, string>() {{ProviderNames.AniList, this.id.ToString()}}
             };
-            
+
             if (this.status == "FINISHED" || this.status == "CANCELLED")
             {
                 result.Status = SeriesStatus.Ended;
@@ -301,7 +301,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 PremiereDate = this.GetStartDate(),
                 EndDate = this.GetStartDate(),
                 CommunityRating = this.GetRating(),
-                Genres = this.genres.ToArray(),
+                Genres = this.GetGenres().ToArray(),
                 Tags = this.GetTagNames().ToArray(),
                 Studios = this.GetStudioNames().ToArray(),
                 ProviderIds = new Dictionary<string, string>() {{ProviderNames.AniList, this.id.ToString()}}

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -215,6 +215,12 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                     });
                 }
             }
+
+            if (config.MaxPeople > 0)
+            {
+                lpi = lpi.Take(config.MaxPeople).ToList();
+            }
+
             return lpi;
         }
 


### PR DESCRIPTION
Hello, as requested in #43 I added an option to limit the amount of people in metadata search results.
There is a new option in the plugin config to configure this behaviour.
Changing this setting from the default 0 (unlimited, just as before) to n will only save the first n people as returned by AniList.
This setting applies only to new metadata on media updates / identifications.
Existing metadata is not altered.
![Screenshot_from_2024-04-19_18-28-14](https://github.com/jellyfin/jellyfin-plugin-anilist/assets/6298910/028d9b9d-6fc5-44c5-be0e-5b739f531d43)
![Screenshot_from_2024-04-19_18-28-51](https://github.com/jellyfin/jellyfin-plugin-anilist/assets/6298910/3b09e294-062c-4ec0-8e1d-334223bf9e3e)
![Screenshot_from_2024-04-19_18-27-37](https://github.com/jellyfin/jellyfin-plugin-anilist/assets/6298910/c0d4e3ff-7ea7-4320-b48a-cf65f4a689b5)
