### PR TITLE
Feature:  Decouples VA filter from the title language, and moves to the new Anilist StaffLanguage API key

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -25,12 +25,19 @@ namespace Jellyfin.Plugin.AniList.Configuration
         None, Anime, Animation
     }
 
+    public enum LanguageFilterType {
+        Localized,
+        Japanese,
+        All
+    }
+
     public class PluginConfiguration : BasePluginConfiguration
     {
         public PluginConfiguration()
         {
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
+            PersonLanguageFilterPreference = LanguageFilterType.All;
             MaxGenres = 5;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
             AniDbRateLimit = 2000;
@@ -43,6 +50,8 @@ namespace Jellyfin.Plugin.AniList.Configuration
 
         public TitlePreferenceType OriginalTitlePreference { get; set; }
 
+        public LanguageFilterType PersonLanguageFilterPreference { get; set; }
+
         public int MaxGenres { get; set; }
 
         public AnimeDefaultGenreType AnimeDefaultGenre { get; set; }
@@ -52,8 +61,6 @@ namespace Jellyfin.Plugin.AniList.Configuration
         public bool AniDbReplaceGraves { get; set; }
 
         public bool AniListShowSpoilerTags { get; set; }
-
-        public bool FilterPeopleByTitlePreference { get; set; }
 
         public bool UseAnitomyLibrary { get; set; }
 

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -35,22 +35,6 @@
                             </select>
                             <div class="fieldDescription">This setting will only keep people with chosen language. Localized retains everything except Japanese.</div>
                         </div>
-                        <div class="paperList checkboxList checkboxList-paperList">
-                            <div data-role="controlgroup">
-                                <label class="emby-checkbox-label">
-                                    <input is="emby-checkbox"  id="mainCharacters" type="checkbox" name="Main Characters"> 
-                                    <span class="checkboxLabel">Main character</span>
-                                </label>
-                                <label class="emby-checkbox-label">
-                                    <input is="emby-checkbox" id="supportingCharacter" type="checkbox" name="Supporting Characters"> 
-                                    <span class="checkboxLabel">Supporting character</span>
-                                </label>
-                                <label class="emby-checkbox-label">
-                                    <input is="emby-checkbox" id="backgroundCharacter" type="checkbox" name="English Movies"> 
-                                    <span class="checkboxLabel">Background Character</span>
-                                </label>
-                            </div>
-                        </div>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -26,11 +26,14 @@
                                 <option id="optLanguageJapaneseRomaji" value="JapaneseRomaji">Romaji</option>
                             </select>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input id="chkFilterPeopleByTitlePreference" name="chkFilterPeopleByTitlePreference" type="checkbox" is="emby-checkbox" />
-                                <span>Filter people by title preference</span>
-                            </label>
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="filterPeopleByLanguage">Filter people by language preference</label>
+                            <select is="emby-select" id="filterPeopleByLanguage" name="filterPeopleByLanguage" class="emby-select-withcolor emby-select">
+                                <option id="optLanguageLocalized" value="Localized">Localized (</option>
+                                <option id="optLanguageJapanese" value="Japanese">Japanese</option>
+                                <option id="optLanguageAll" value="All">Do not filter</option>
+                                <div class="fieldDescription">This setting will only retain the people with the language chosen above. Localized keeps everything except Japanese.</div>
+                            </select>
                         </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
@@ -87,7 +90,7 @@
                         ApiClient.getPluginConfiguration(AniListConfigurationPage.pluginUniqueId).then(function (config) {
                             document.getElementById('titleLanguage').value = config.TitlePreference;
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
-                            document.getElementById('chkFilterPeopleByTitlePreference').checked = config.FilterPeopleByTitlePreference;
+                            document.getElementById('filterPeopleByLanguage').value = config.PersonLanguageFilterPreference;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
@@ -105,7 +108,7 @@
                         ApiClient.getPluginConfiguration(AniListConfigurationPage.pluginUniqueId).then(function (config) {
                             config.TitlePreference = document.getElementById('titleLanguage').value;
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
-                            config.FilterPeopleByTitlePreference = document.getElementById('chkFilterPeopleByTitlePreference').checked;
+                            config.PersonLanguageFilterPreference = document.getElementById('filterPeopleByLanguage').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -29,11 +29,11 @@
                         <div class="selectContainer">
                             <label class="selectLabel" for="filterPeopleByLanguage">Filter people by language preference</label>
                             <select is="emby-select" id="filterPeopleByLanguage" name="filterPeopleByLanguage" class="emby-select-withcolor emby-select">
-                                <option id="optLanguageLocalized" value="Localized">Localized (</option>
+                                <option id="optLanguageLocalized" value="Localized">Localized</option>
                                 <option id="optLanguageJapanese" value="Japanese">Japanese</option>
                                 <option id="optLanguageAll" value="All">Do not filter</option>
-                                <div class="fieldDescription">This setting will only retain the people with the language chosen above. Localized keeps everything except Japanese.</div>
                             </select>
+                            <div class="fieldDescription">This setting will only retain the people with the language chosen above. Localized keeps everything except Japanese.</div>
                         </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -27,13 +27,13 @@
                             </select>
                         </div>
                         <div class="selectContainer">
-                            <label class="selectLabel" for="filterPeopleByLanguage">Filter people by language preference</label>
+                            <label class="selectLabel" for="filterPeopleByLanguage">Filter People by Language Preference</label>
                             <select is="emby-select" id="filterPeopleByLanguage" name="filterPeopleByLanguage" class="emby-select-withcolor emby-select">
                                 <option id="optLanguageLocalized" value="Localized">Localized</option>
                                 <option id="optLanguageJapanese" value="Japanese">Japanese</option>
                                 <option id="optLanguageAll" value="All">Do not filter</option>
                             </select>
-                            <div class="fieldDescription">This setting will only keep people with chosen language. Localized retains everything except Japanese.</div>
+                            <div class="fieldDescription">This setting will only keep people with chosen language. Choosing Localized will retain everybody except Japanese VAs.</div>
                         </div>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -33,10 +33,26 @@
                                 <option id="optLanguageJapanese" value="Japanese">Japanese</option>
                                 <option id="optLanguageAll" value="All">Do not filter</option>
                             </select>
-                            <div class="fieldDescription">This setting will only retain the people with the language chosen above. Localized keeps everything except Japanese.</div>
+                            <div class="fieldDescription">This setting will only keep people with chosen language. Localized retains everything except Japanese.</div>
+                        </div>
+                        <div class="paperList checkboxList checkboxList-paperList">
+                            <div data-role="controlgroup">
+                                <label class="emby-checkbox-label">
+                                    <input is="emby-checkbox"  id="mainCharacters" type="checkbox" name="Main Characters"> 
+                                    <span class="checkboxLabel">Main character</span>
+                                </label>
+                                <label class="emby-checkbox-label">
+                                    <input is="emby-checkbox" id="supportingCharacter" type="checkbox" name="Supporting Characters"> 
+                                    <span class="checkboxLabel">Supporting character</span>
+                                </label>
+                                <label class="emby-checkbox-label">
+                                    <input is="emby-checkbox" id="backgroundCharacter" type="checkbox" name="English Movies"> 
+                                    <span class="checkboxLabel">Background Character</span>
+                                </label>
+                            </div>
                         </div>
                         <div class="inputContainer">
-                            <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
+                            <label class="inputLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">Set this to zero to remove any limit.</div>
                         </div>
@@ -49,7 +65,7 @@
                             </select>
                         </div>
                         <div class="inputContainer">
-                            <label class="inputeLabel inputLabelUnfocused" for="chkAniDbRateLimit">AniDB Rate Limit</label>
+                            <label class="inputLabel inputLabelUnfocused" for="chkAniDbRateLimit">AniDB Rate Limit</label>
                             <input id="chkAniDbRateLimit" name="chkAniDbRateLimit" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">This will prevent IP bans for requesting data too quickly.</div>
                         </div>

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -129,7 +129,7 @@ query($id: Int!, $type: MediaType) {
             medium
             large
           }
-          language
+          language: languageV2
         }
       }
     }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -273,7 +273,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 Studios = this.GetStudioNames().ToArray(),
                 ProviderIds = new Dictionary<string, string>() {{ProviderNames.AniList, this.id.ToString()}}
             };
-            
+
             if (this.status == "FINISHED" || this.status == "CANCELLED")
             {
                 result.Status = SeriesStatus.Ended;
@@ -301,7 +301,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 PremiereDate = this.GetStartDate(),
                 EndDate = this.GetStartDate(),
                 CommunityRating = this.GetRating(),
-                Genres = this.genres.ToArray(),
+                Genres = this.GetGenres().ToArray(),
                 Tags = this.GetTagNames().ToArray(),
                 Studios = this.GetStudioNames().ToArray(),
                 ProviderIds = new Dictionary<string, string>() {{ProviderNames.AniList, this.id.ToString()}}

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -198,11 +198,11 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             {
                 foreach (VoiceActor va in edge.voiceActors)
                 {
-                    if (config.FilterPeopleByTitlePreference) {
-                        if (config.TitlePreference != TitlePreferenceType.Localized && va.language != "JAPANESE") {
+                    if (config.PersonLanguageFilterPreference != LanguageFilterType.All) {
+                        if (config.PersonLanguageFilterPreference == LanguageFilterType.Japanese && va.language != "JAPANESE") {
                             continue;
                         }
-                        if (config.TitlePreference == TitlePreferenceType.Localized && va.language == "JAPANESE") {
+                        if (config.PersonLanguageFilterPreference == LanguageFilterType.Localized && va.language == "JAPANESE") {
                             continue;
                         }
                     }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -199,10 +199,10 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 foreach (VoiceActor va in edge.voiceActors)
                 {
                     if (config.PersonLanguageFilterPreference != LanguageFilterType.All) {
-                        if (config.PersonLanguageFilterPreference == LanguageFilterType.Japanese && va.language != "JAPANESE") {
+                        if (config.PersonLanguageFilterPreference == LanguageFilterType.Japanese && va.language != "Japanese") {
                             continue;
                         }
-                        if (config.PersonLanguageFilterPreference == LanguageFilterType.Localized && va.language == "JAPANESE") {
+                        if (config.PersonLanguageFilterPreference == LanguageFilterType.Localized && va.language == "Japanese") {
                             continue;
                         }
                     }


### PR DESCRIPTION
This PR fixes #58, and improves the behavior of #32 (paging @As4shi since I found their fork mentioned here which is a very similar independent implementation of this.)

Now, there's a separate selector with an option to choose between JP, non-JP, and "Do not Filter" options. The default choice is "Do not Filter":

<img width="883" alt="Screen Shot 2024-04-28 at 12 42 00 AM@2x" src="https://github.com/jellyfin/jellyfin-plugin-anilist/assets/23611514/28894143-762b-42bf-aeb2-031cdd078718">

Additionally, there's changes the GraphQL query to reference the new languageV2 key and corresponding code changes to make Language choice independent from Title/Original Title choices.

https://github.com/mmshivesh/jellyfin-plugin-anilist/blob/f05f38e77542bb425bfbd7b0748c8158d606ebb5/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs#L132


A built .dll of this version can be found on the fork here: https://github.com/mmshivesh/jellyfin-plugin-anilist/actions/runs/8864938203

Testing:

- The test action was run, and passed successfully.
- Have been personally using this version and did a full metadata refresh of my library to perfect results.

Future Work:
- This also lays groundwork to let users filter VAs on the basis of any language (maybe with an Include/Exclude these languages box?)

Note: Basing this off of Unstable branch
