### PR TITLE
WIP Feature: Character role based filters (Main, Supporting and Background)

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -38,6 +38,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
             PersonLanguageFilterPreference = LanguageFilterType.All;
+            RoleFilter = new string[]{"mainCharacter", "supportingCharacter"};
             MaxPeople = 0;
             MaxGenres = 5;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
@@ -46,6 +47,8 @@ namespace Jellyfin.Plugin.AniList.Configuration
             AniListShowSpoilerTags = true;
             UseAnitomyLibrary = false;
         }
+
+        public string[] RoleFilter { get; set; }
 
         public TitlePreferenceType TitlePreference { get; set; }
 

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -28,6 +28,7 @@
                             </select>
                         </div>
                         <h2>People Filters</h2>
+                        <div>The following filters can be used together to trim the list of people shown under a show or a movie.</div>
                         <div class="selectContainer">
                             <label class="selectLabel" for="filterPeopleByLanguage">By Language Preference</label>
                             <select is="emby-select" id="filterPeopleByLanguage" name="filterPeopleByLanguage" class="emby-select-withcolor emby-select">

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -10,6 +10,7 @@
             <div data-role="content">
                 <div class="content-primary">
                     <form id="aniListConfigurationForm">
+                        <h2>Language Settings</h2>
                         <div class="selectContainer">
                             <label class="selectLabel" for="titleLanguage">Title Language</label>
                             <select is="emby-select" id="titleLanguage" name="titleLanguage" class="emby-select-withcolor emby-select">
@@ -26,15 +27,37 @@
                                 <option id="optLanguageJapaneseRomaji" value="JapaneseRomaji">Romaji</option>
                             </select>
                         </div>
+                        <h2>People Filters</h2>
                         <div class="selectContainer">
-                            <label class="selectLabel" for="filterPeopleByLanguage">Filter People by Language Preference</label>
+                            <label class="selectLabel" for="filterPeopleByLanguage">By Language Preference</label>
                             <select is="emby-select" id="filterPeopleByLanguage" name="filterPeopleByLanguage" class="emby-select-withcolor emby-select">
                                 <option id="optLanguageLocalized" value="Localized">Localized</option>
                                 <option id="optLanguageJapanese" value="Japanese">Japanese</option>
                                 <option id="optLanguageAll" value="All">Do not filter</option>
                             </select>
-                            <div class="fieldDescription">This setting will only keep people with chosen language. Choosing Localized will retain everybody except Japanese VAs.</div>
+                            <div class="fieldDescription">This setting will only include people with chosen language. Choosing "Localized" will retain everybody except Japanese VAs.</div>
                         </div>
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="filterPeopleByLanguage">By Character Role</label>
+                            <div class="paperList checkboxList checkboxList-paperList">
+                                <div data-role="controlgroup">
+                                    <label class="emby-checkbox-label">
+                                        <input is="emby-checkbox" class="characterRole" id="mainCharacter" type="checkbox" name="Main Characters"> 
+                                        <span class="checkboxLabel">Main Characters</span>
+                                    </label>
+                                    <label class="emby-checkbox-label">
+                                        <input is="emby-checkbox" class="characterRole" id="supportingCharacter" type="checkbox" name="Supporting Characters"> 
+                                        <span class="checkboxLabel">Supporting Characters</span>
+                                    </label>
+                                    <label class="emby-checkbox-label">
+                                        <input is="emby-checkbox" class="characterRole" id="backgroundCharacter" type="checkbox" name="English Movies"> 
+                                        <span class="checkboxLabel">Background Characters</span>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="fieldDescription">This setting will only keep people with the specific Character Role.</div>
+                        </div>
+                        <h2>Genre Settings</h2>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="chkMaxPeople">Max People</label>
                             <input id="chkMaxPeople" name="chkMaxPeople" type="number" is="emby-input" min="0" />
@@ -53,6 +76,7 @@
                                 <option id="optDefaultGenreAnimation" value="Animation">Animation</option>
                             </select>
                         </div>
+                        <h2>AniDB Settings</h2>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="chkAniDbRateLimit">AniDB Rate Limit</label>
                             <input id="chkAniDbRateLimit" name="chkAniDbRateLimit" type="number" is="emby-input" min="0" />
@@ -64,6 +88,7 @@
                                 <span>AniDB Replace Grave Characters</span>
                             </label>
                         </div>
+                        <h2>Other Settings</h2>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="chkAniListShowSpoilerTags" name="chkAniListShowSpoilerTags" type="checkbox" is="emby-checkbox" />
@@ -97,6 +122,12 @@
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('filterPeopleByLanguage').value = config.PersonLanguageFilterPreference;
                             document.getElementById('chkMaxPeople').value = config.MaxPeople;
+                            for (filter of config.RoleFilter) {
+                                document.getElementById(filter).checked = true;
+                            }
+//                            for (char in ['mainCharacter', 'supportingCharacter','backgroundCharacter']) {
+//                                document.getElementById(char).checked = config.RoleFilter[char];
+//                            }
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
@@ -116,13 +147,18 @@
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.PersonLanguageFilterPreference = document.getElementById('filterPeopleByLanguage').value;
                             config.MaxPeople = document.getElementById('chkMaxPeople').value;
+                            config.RoleFilter = Array.prototype.map.call(document.querySelectorAll('.characterRole:checked'), element => {
+                                return element.getAttribute('id');
+                            });
+//                            for (char in ['mainCharacter', 'supportingCharacter','backgroundCharacter']) {
+//                                config.RoleFilter.push({key: char, value: document.getElementById(char).checked});
+//                            }
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;
                             config.AniListShowSpoilerTags = document.getElementById('chkAniListShowSpoilerTags').checked;
                             config.UseAnitomyLibrary = document.getElementById('chkUseAnitomyLibrary').checked;
-
                             ApiClient.updatePluginConfiguration(AniListConfigurationPage.pluginUniqueId, config).then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);
                             });


### PR DESCRIPTION
Draft Pull request adding support for role based filtering of Characters included in the metadata:

- Introduces a selection group with option to choose between Main, Supporting and Background Character filters. Can be grouped together with the filters included in #65 to dial in exactly the Voice actors to include in the metadata.
<img width="870" alt="Screen Shot 2024-04-29 at 02 37 23 AM@2x" src="https://github.com/jellyfin/jellyfin-plugin-anilist/assets/23611514/ef876401-f1ac-4af9-8406-45676f03dd7b">

- UI Improvements incorporating headings and logical grouping of multiple settings (TODO: ensure setting added in #66 is in the right section)


Testing:
- Rebased on top of the v9 branch, therefore testing not done yet. Build using github action fails [here](https://github.com/mmshivesh/jellyfin-plugin-anilist/actions/runs/9141535429) because of a change made from PersonType to "PersonKind" in 89c62c9
- Older version prior to v8 works fine, and has been tested personally.
- TODO: Need to verify compatibility with #66

Opening a Draft PR for the following reasons:

1. Would it be a good idea to revert the change with naïve VA count filters (#66) with this smarter system based on character role
2. UI feedback
3. Get more pairs of eyes on it for testing, questions about the PersonType -> PersonKind changes