### PR TITLE
Added a setting to make only animation studio appear as metadata (with fixes)

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -45,6 +45,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
             AniDbReplaceGraves = true;
             AniListShowSpoilerTags = true;
             UseAnitomyLibrary = false;
+            OnlyAnimationStudios = false;
         }
 
         public TitlePreferenceType TitlePreference { get; set; }
@@ -67,5 +68,6 @@ namespace Jellyfin.Plugin.AniList.Configuration
 
         public bool UseAnitomyLibrary { get; set; }
 
+        public bool OnlyAnimationStudios { get; set; }
     }
 }

--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -31,6 +31,12 @@ namespace Jellyfin.Plugin.AniList.Configuration
         All
     }
 
+    public enum StudioFilterType {
+        MainOnly,
+        AnimationStudioOnly,
+        All
+    }
+
     public class PluginConfiguration : BasePluginConfiguration
     {
         public PluginConfiguration()
@@ -41,11 +47,11 @@ namespace Jellyfin.Plugin.AniList.Configuration
             MaxPeople = 0;
             MaxGenres = 5;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
+            StudioFilterPreference = StudioFilterType.All;
             AniDbRateLimit = 2000;
             AniDbReplaceGraves = true;
             AniListShowSpoilerTags = true;
             UseAnitomyLibrary = false;
-            OnlyAnimationStudios = false;
         }
 
         public TitlePreferenceType TitlePreference { get; set; }
@@ -58,6 +64,8 @@ namespace Jellyfin.Plugin.AniList.Configuration
 
         public int MaxGenres { get; set; }
 
+        public StudioFilterType StudioFilterPreference { get; set; }
+
         public AnimeDefaultGenreType AnimeDefaultGenre { get; set; }
 
         public int AniDbRateLimit { get; set; }
@@ -67,7 +75,5 @@ namespace Jellyfin.Plugin.AniList.Configuration
         public bool AniListShowSpoilerTags { get; set; }
 
         public bool UseAnitomyLibrary { get; set; }
-
-        public bool OnlyAnimationStudios { get; set; }
     }
 }

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -46,6 +46,15 @@
                             <div class="fieldDescription">Set this to zero to remove any limit.</div>
                         </div>
                         <div class="selectContainer">
+                            <label class="selectLabel" for="filterStudio">Filter Studio Preference</label>
+                            <select is="emby-select" id="filterStudio" name="filterStudio" class="emby-select-withcolor emby-select">
+                                <option id="optStudioAll" value="All">Do not filter</option>
+                                <option id="optStudioMain" value="MainOnly">Keep main studio</option>
+                                <option id="optStudioAnimationStudio" value="AnimationStudioOnly">Keep all animation studios</option>
+                            </select>
+                            <div class="fieldDescription">This setting will change how studios are filtered. Sometimes the main studio is not an animation studio so keeping only animation studios might result in no studios being kept.</div>
+                        </div>
+                        <div class="selectContainer">
                             <label class="selectLabel" for="animeDefaultGenre">Anime Default Genre Name</label>
                             <select is="emby-select" id="animeDefaultGenre" name="animeDefaultGenre" class="emby-select-withcolor emby-select">
                                 <option id="optDefaultGenreNone" value="None">None</option>
@@ -76,12 +85,6 @@
                                 <span>Use the Anitomy library to resolve titles</span>
                             </label>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label class="emby-checkbox-label">
-                                <input id="chkOnlyAnimationStudios" name="chkOnlyAnimationStudios" type="checkbox" is="emby-checkbox" />
-                                <span>Only get studios that are animation studios</span>
-                            </label>
-                        </div>
                         <div>
                             <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                                 <span>Save</span>
@@ -104,12 +107,12 @@
                             document.getElementById('filterPeopleByLanguage').value = config.PersonLanguageFilterPreference;
                             document.getElementById('chkMaxPeople').value = config.MaxPeople;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
+                            document.getElementById('filterStudio').value = config.StudioFilterPreference;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
                             document.getElementById('chkAniDbReplaceGraves').checked = config.AniDbReplaceGraves;
                             document.getElementById('chkAniListShowSpoilerTags').checked = config.AniListShowSpoilerTags;
                             document.getElementById('chkUseAnitomyLibrary').checked = config.UseAnitomyLibrary;
-                            document.getElementById('chkOnlyAnimationStudios').checked = config.OnlyAnimationStudios;
 
                             Dashboard.hideLoadingMsg();
                         });
@@ -124,12 +127,12 @@
                             config.PersonLanguageFilterPreference = document.getElementById('filterPeopleByLanguage').value;
                             config.MaxPeople = document.getElementById('chkMaxPeople').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
+                            config.StudioFilterPreference = document.getElementById('filterStudio').value;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;
                             config.AniListShowSpoilerTags = document.getElementById('chkAniListShowSpoilerTags').checked;
                             config.UseAnitomyLibrary = document.getElementById('chkUseAnitomyLibrary').checked;
-                            config.OnlyAnimationStudios = document.getElementById('chkOnlyAnimationStudios').checked;
 
                             ApiClient.updatePluginConfiguration(AniListConfigurationPage.pluginUniqueId, config).then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -76,6 +76,12 @@
                                 <span>Use the Anitomy library to resolve titles</span>
                             </label>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkOnlyAnimationStudios" name="chkOnlyAnimationStudios" type="checkbox" is="emby-checkbox" />
+                                <span>Only get studios that are animation studios</span>
+                            </label>
+                        </div>
                         <div>
                             <button is="emby-button" type="submit" class="raised button-submit block emby-button">
                                 <span>Save</span>
@@ -103,6 +109,7 @@
                             document.getElementById('chkAniDbReplaceGraves').checked = config.AniDbReplaceGraves;
                             document.getElementById('chkAniListShowSpoilerTags').checked = config.AniListShowSpoilerTags;
                             document.getElementById('chkUseAnitomyLibrary').checked = config.UseAnitomyLibrary;
+                            document.getElementById('chkOnlyAnimationStudios').checked = config.OnlyAnimationStudios;
 
                             Dashboard.hideLoadingMsg();
                         });
@@ -122,6 +129,7 @@
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;
                             config.AniListShowSpoilerTags = document.getElementById('chkAniListShowSpoilerTags').checked;
                             config.UseAnitomyLibrary = document.getElementById('chkUseAnitomyLibrary').checked;
+                            config.chkOnlyAnimationStudios = document.getElementById('chkOnlyAnimationStudios').checked;
 
                             ApiClient.updatePluginConfiguration(AniListConfigurationPage.pluginUniqueId, config).then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -129,7 +129,7 @@
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;
                             config.AniListShowSpoilerTags = document.getElementById('chkAniListShowSpoilerTags').checked;
                             config.UseAnitomyLibrary = document.getElementById('chkUseAnitomyLibrary').checked;
-                            config.chkOnlyAnimationStudios = document.getElementById('chkOnlyAnimationStudios').checked;
+                            config.OnlyAnimationStudios = document.getElementById('chkOnlyAnimationStudios').checked;
 
                             ApiClient.updatePluginConfiguration(AniListConfigurationPage.pluginUniqueId, config).then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -100,10 +100,13 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 }
 
                 studios {
-                  nodes {
-                    id
-                    name
-                    isAnimationStudio
+                  edges {
+                    node {
+                      id
+                      name
+                      isAnimationStudio
+                    }
+                    isMain
                   }
                 }
                 characters(sort: [ROLE, FAVOURITES_DESC]) {

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -165,7 +165,8 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             List<string> results = new List<string>();
             foreach (Studio node in this.studios.nodes)
             {
-                results.Add(node.name);
+                if (node.isAnimationStudio)
+                    results.Add(node.name);
             }
             return results;
         }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -165,11 +165,18 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             PluginConfiguration config = Plugin.Instance.Configuration;
 
             List<string> results = new List<string>();
-            foreach (Studio node in this.studios.nodes)
+            foreach (StudioEdge edge in this.studios.edges)
             {
-                if (!config.OnlyAnimationStudios || node.isAnimationStudio)
+                if (
+                  !results.Contains(edge.node.name) &&
+                  (
+                    config.StudioFilterPreference == StudioFilterType.All ||
+                    (config.StudioFilterPreference == StudioFilterType.MainOnly && edge.isMain) ||
+                    (config.StudioFilterPreference == StudioFilterType.AnimationStudioOnly && edge.node.isAnimationStudio)
+                  )
+                )
                 {
-                    results.Add(node.name);
+                    results.Add(edge.node.name);
                 }
             }
             return results;
@@ -448,9 +455,15 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         public bool isAnimationStudio { get; set; }
     }
 
+    public class StudioEdge
+    {
+        public Studio node { get; set; }
+        public bool isMain { get; set; }
+    }
+
     public class StudioConnection
     {
-        public List<Studio> nodes { get; set; }
+        public List<StudioEdge> edges { get; set; }
     }
 
     public class RootObject

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -167,14 +167,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             List<string> results = new List<string>();
             foreach (Studio node in this.studios.nodes)
             {
-                if (config.OnlyAnimationStudios)
-                {
-                    if (node.isAnimationStudio)
-                    {
-                        results.Add(node.name);
-                    }
-                }
-                else
+                if (!config.OnlyAnimationStudios || node.isAnimationStudio)
                 {
                     results.Add(node.name);
                 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -162,11 +162,22 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         /// <returns></returns>
         public List<string> GetStudioNames()
         {
+            PluginConfiguration config = Plugin.Instance.Configuration;
+
             List<string> results = new List<string>();
             foreach (Studio node in this.studios.nodes)
             {
-                if (node.isAnimationStudio)
+                if (config.OnlyAnimationStudios)
+                {
+                    if (node.isAnimationStudio)
+                    {
+                        results.Add(node.name);
+                    }
+                }
+                else
+                {
                     results.Add(node.name);
+                }
             }
             return results;
         }


### PR DESCRIPTION
While testing https://github.com/jellyfin/jellyfin-plugin-anilist/pull/81 (as I would really like to see this merged) I hit a few snags, see the comments of that PR for more info.

This build on that PR and the work of @rzk3 

- Apply @nielsvanvelzen suggestion
- Make the new configuration option an Enum between 'All, MainOnly, AnimationStudioOnly'
- Update GraphQL query to fetch edges instead of nodes to get access to the edge.isMain property
- Update logic in ApiModel to either return all studios (= Studio + Producer section on AniList Website), main studio only (= Studio section on AniList Website - what most people would probably want), animation studio only (= does not map to website but what the original PR implemented which resulted in a lot of cases with no studios or sometimes still multiple)

Possible improvements:
- change it back to a checkbox but call it `Keep main studio only` but I am not 100% sure if this is what the intend was of @rzk3, but it is certainly more in line with what I would have expected
- ideally @rzk3 replies/has time and they can just cherry pick some things from this as I would prefer this and this PR can be closed instead, but the old PR has been dormant for a while and with my testing I though I'd push this forward a bit myself.

Edit: currently updating my entire Anime library and will check if any more weird cases pop up, but so far doing just A->C it looks good. This will probably take the rest of the day.