### PR TITLE
Add option for including/excluding series description (synopsis)

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.AniList.Configuration
 {
@@ -44,6 +44,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
             PersonLanguageFilterPreference = LanguageFilterType.All;
+            AddDescription = true;
             MaxPeople = 0;
             MaxGenres = 5;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
@@ -59,6 +60,8 @@ namespace Jellyfin.Plugin.AniList.Configuration
         public TitlePreferenceType OriginalTitlePreference { get; set; }
 
         public LanguageFilterType PersonLanguageFilterPreference { get; set; }
+
+        public bool AddDescription { get; set; }
 
         public int MaxPeople { get; set; }
 

--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -44,7 +44,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
             PersonLanguageFilterPreference = LanguageFilterType.All;
-            AddDescription = true;
+            AddOverview = true;
             MaxPeople = 0;
             MaxGenres = 5;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
@@ -61,7 +61,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
 
         public LanguageFilterType PersonLanguageFilterPreference { get; set; }
 
-        public bool AddDescription { get; set; }
+        public bool AddOverview { get; set; }
 
         public int MaxPeople { get; set; }
 

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -34,6 +34,12 @@
                                 <option id="optLanguageAll" value="All">Do not filter</option>
                             </select>
                             <div class="fieldDescription">This setting will only keep people with chosen language. Choosing Localized will retain everybody except Japanese VAs.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkAddDescription" name="chkAddDescription" type="checkbox" is="emby-checkbox" />
+                                <span>Include synopsis metadata</span>
+                            </label>
                         </div>
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="chkMaxPeople">Max People</label>
@@ -105,6 +111,7 @@
                             document.getElementById('titleLanguage').value = config.TitlePreference;
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('filterPeopleByLanguage').value = config.PersonLanguageFilterPreference;
+                            document.getElementById('chkAddDescription').checked = config.AddDescription;
                             document.getElementById('chkMaxPeople').value = config.MaxPeople;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('filterStudio').value = config.StudioFilterPreference;
@@ -125,6 +132,7 @@
                             config.TitlePreference = document.getElementById('titleLanguage').value;
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.PersonLanguageFilterPreference = document.getElementById('filterPeopleByLanguage').value;
+                            config.AddDescription = document.getElementById('chkAddDescription').checked;
                             config.MaxPeople = document.getElementById('chkMaxPeople').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.StudioFilterPreference = document.getElementById('filterStudio').value;

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -37,8 +37,8 @@
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
-                                <input id="chkAddDescription" name="chkAddDescription" type="checkbox" is="emby-checkbox" />
-                                <span>Include synopsis metadata</span>
+                                <input id="chkAddOverview" name="chkAddOverview" type="checkbox" is="emby-checkbox" />
+                                <span>Include series overview metadata</span>
                             </label>
                         </div>
                         <div class="inputContainer">
@@ -111,7 +111,7 @@
                             document.getElementById('titleLanguage').value = config.TitlePreference;
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('filterPeopleByLanguage').value = config.PersonLanguageFilterPreference;
-                            document.getElementById('chkAddDescription').checked = config.AddDescription;
+                            document.getElementById('chkAddOverview').checked = config.AddOverview;
                             document.getElementById('chkMaxPeople').value = config.MaxPeople;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('filterStudio').value = config.StudioFilterPreference;
@@ -132,7 +132,7 @@
                             config.TitlePreference = document.getElementById('titleLanguage').value;
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.PersonLanguageFilterPreference = document.getElementById('filterPeopleByLanguage').value;
-                            config.AddDescription = document.getElementById('chkAddDescription').checked;
+                            config.AddOverview = document.getElementById('chkAddOverview').checked;
                             config.MaxPeople = document.getElementById('chkMaxPeople').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.StudioFilterPreference = document.getElementById('filterStudio').value;

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Data.Enums;
@@ -271,7 +271,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             var result = new Series {
                 Name = GetPreferredTitle(config.TitlePreference, "en"),
                 OriginalTitle = GetPreferredTitle(config.OriginalTitlePreference, "en"),
-                Overview = config.AddDescription ? description : null,
+                Overview = config.AddOverview ? description : null,
                 ProductionYear = startDate.year,
                 PremiereDate = startDate?.ToDateTime(),
                 EndDate = endDate?.ToDateTime(),
@@ -309,7 +309,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             return new Movie {
                 Name = GetPreferredTitle(config.TitlePreference, "en"),
                 OriginalTitle = GetPreferredTitle(config.OriginalTitlePreference, "en"),
-                Overview = config.AddDescription ? description : null,
+                Overview = config.AddOverview ? description : null,
                 ProductionYear = startDate.year,
                 PremiereDate = startDate?.ToDateTime(),
                 EndDate = endDate?.ToDateTime(),

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Data.Enums;
@@ -271,7 +271,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             var result = new Series {
                 Name = GetPreferredTitle(config.TitlePreference, "en"),
                 OriginalTitle = GetPreferredTitle(config.OriginalTitlePreference, "en"),
-                Overview = description,
+                Overview = config.AddDescription ? description : null,
                 ProductionYear = startDate.year,
                 PremiereDate = startDate?.ToDateTime(),
                 EndDate = endDate?.ToDateTime(),
@@ -309,7 +309,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             return new Movie {
                 Name = GetPreferredTitle(config.TitlePreference, "en"),
                 OriginalTitle = GetPreferredTitle(config.OriginalTitlePreference, "en"),
-                Overview = description,
+                Overview = config.AddDescription ? description : null,
                 ProductionYear = startDate.year,
                 PremiereDate = startDate?.ToDateTime(),
                 EndDate = endDate?.ToDateTime(),


### PR DESCRIPTION
This addresses the use-case where a user wants to get some metadata from AniList (e.g. tags, genre) but wants to fallback on a different plugin for the series synopsis (e.g. a non-English metadata provider).

Closes #96 