### PR TITLE
Change image type for banner images from Backdrop to Banner

### DIFF
--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListAnimeImageProvider.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListAnimeImageProvider.cs
@@ -58,7 +58,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                         list.Add(new RemoteImageInfo
                         {
                             ProviderName = Name,
-                            Type = ImageType.Backdrop,
+                            Type = ImageType.Banner,
                             Url = media.bannerImage
                         });
                     }


### PR DESCRIPTION
Reverts #37
Fixes #108 (and #70, #51)

Banners from AniList are (usually) in 1700x330 resolution, Backdrops should be in or close to 16:9 format like from all other metadata providers.