### PR TITLE
Allow filtering people by role

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -37,6 +37,13 @@ namespace Jellyfin.Plugin.AniList.Configuration
         All
     }
 
+    public enum PersonRoleFilter
+    {
+        Main = 0,
+        Supporting = 1,
+        Background = 2,
+    }
+
     public class PluginConfiguration : BasePluginConfiguration
     {
         public PluginConfiguration()
@@ -44,6 +51,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
             TitlePreference = TitlePreferenceType.Localized;
             OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
             PersonLanguageFilterPreference = LanguageFilterType.All;
+            PersonRoleFilterPreference = PersonRoleFilter.Background;
             AddOverview = true;
             MaxPeople = 0;
             MaxGenres = 5;
@@ -62,6 +70,8 @@ namespace Jellyfin.Plugin.AniList.Configuration
         public TitlePreferenceType OriginalTitlePreference { get; set; }
 
         public LanguageFilterType PersonLanguageFilterPreference { get; set; }
+
+        public PersonRoleFilter PersonRoleFilterPreference { get; set; }
 
         public bool AddOverview { get; set; }
 

--- a/Jellyfin.Plugin.AniList/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniList/Configuration/configPage.html
@@ -35,6 +35,14 @@
                             </select>
                             <div class="fieldDescription">This setting will only keep people with chosen language. Choosing Localized will retain everybody except Japanese VAs.</div>
                         </div>
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="personRoleFilter">Filter People by Role</label>
+                            <select is="emby-select" id="personRoleFilter" name="personRoleFilter" class="emby-select-withcolor emby-select">
+                                <option id="optPersonRoleFilterMain" value="Main">Main only</option>
+                                <option id="optPersonRoleFilterSupporting" value="Supporting">Main & Supporting</option>
+                                <option id="optPersonRoleFilterBackground" value="Background">Main, Supporting & Background</option>
+                            </select>
+                        </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="chkAddOverview" name="chkAddOverview" type="checkbox" is="emby-checkbox" />
@@ -121,6 +129,7 @@
                             document.getElementById('titleLanguage').value = config.TitlePreference;
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('filterPeopleByLanguage').value = config.PersonLanguageFilterPreference;
+                            document.getElementById('personRoleFilter').value = config.PersonRoleFilterPreference;
                             document.getElementById('chkAddOverview').checked = config.AddOverview;
                             document.getElementById('chkMaxPeople').value = config.MaxPeople;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
@@ -144,6 +153,7 @@
                             config.TitlePreference = document.getElementById('titleLanguage').value;
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.PersonLanguageFilterPreference = document.getElementById('filterPeopleByLanguage').value;
+                            config.PersonRoleFilterPreference = document.getElementById('personRoleFilter').value;
                             config.AddOverview = document.getElementById('chkAddOverview').checked;
                             config.MaxPeople = document.getElementById('chkMaxPeople').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;

--- a/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/ApiModel.cs
@@ -193,6 +193,10 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
 
             foreach (CharacterEdge edge in characters.edges)
             {
+                if (!Enum.TryParse(edge.role, true, out PersonRoleFilter role)
+                    || role > config.PersonRoleFilterPreference)
+                    continue;
+
                 foreach (Staff va in edge.voiceActors)
                 {
                     if (config.PersonLanguageFilterPreference != LanguageFilterType.All)


### PR DESCRIPTION
Add a new configuration setting to allow filtering person results by
their role (main, supporting or background)