### PR TITLE
Implement rate limit and HTTP 429 handling

### DIFF
--- a/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniList/Configuration/PluginConfiguration.cs
@@ -51,7 +51,7 @@ namespace Jellyfin.Plugin.AniList.Configuration
             MinTagRank = 0;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
             StudioFilterPreference = StudioFilterType.All;
-            AniDbRateLimit = 2000;
+            AniDbRateLimit = 30;
             AniDbReplaceGraves = true;
             AniListShowSpoilerTags = true;
             UseAnitomyLibrary = false;

--- a/Jellyfin.Plugin.AniList/Jellyfin.Plugin.AniList.csproj
+++ b/Jellyfin.Plugin.AniList/Jellyfin.Plugin.AniList.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
     <PackageReference Include="AnitomySharp.NET6" Version="0.5.1" />
+    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly.RateLimiting" Version="8.6.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.AniList/Jellyfin.Plugin.AniList.csproj
+++ b/Jellyfin.Plugin.AniList/Jellyfin.Plugin.AniList.csproj
@@ -10,8 +10,6 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
     <PackageReference Include="AnitomySharp.NET6" Version="0.5.1" />
-    <PackageReference Include="Polly" Version="8.6.6" />
-    <PackageReference Include="Polly.RateLimiting" Version="8.6.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -350,6 +350,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                     retryDelay = TimeSpan.FromSeconds(60);
                 }
 
+                await SetNextRequestAfter(retryDelay, cancellationToken).ConfigureAwait(false);
                 _logger?.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} seconds.", retryDelay.TotalSeconds);
                 await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
             }
@@ -397,6 +398,24 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 }
 
                 _nextRequestAt = now + delayBetweenRequests;
+            }
+            finally
+            {
+                _rateLimitLock.Release();
+            }
+        }
+
+        private static async Task SetNextRequestAfter(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                var retryAfter = DateTimeOffset.UtcNow + delay;
+                if (_nextRequestAt < retryAfter)
+                {
+                    _nextRequestAt = retryAfter;
+                }
             }
             finally
             {

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -308,15 +309,61 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         /// <returns></returns>
         private async Task<RootObject> WebRequestAPI(GraphQlRequest request, CancellationToken cancellationToken)
         {
-            await WaitForRateLimit(cancellationToken).ConfigureAwait(false);
-
             var httpClient = Plugin.Instance.GetHttpClient();
+            var requestBody = JsonSerializer.Serialize(request);
+            string responseBody = null;
+            bool success = false;
 
-            using HttpContent content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
-            using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
-            using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                await WaitForRateLimit(cancellationToken).ConfigureAwait(false);
 
-            return await JsonSerializer.DeserializeAsync<RootObject>(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+                using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
+                responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                success = response.IsSuccessStatusCode;
+
+                if (success ||
+                    response.StatusCode != HttpStatusCode.TooManyRequests)
+                {
+                    break;
+                }
+
+                var delay = response.Headers.RetryAfter?.Delta;
+                if (delay is null &&
+                    response.Headers.RetryAfter?.Date is { } retryAfterDate)
+                {
+                    delay = retryAfterDate - DateTimeOffset.UtcNow;
+                }
+
+                var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
+                if (retryDelay <= TimeSpan.Zero)
+                {
+                    // If the Retry-After header is missing or invalid, default to a 60 second delay
+                    retryDelay = TimeSpan.FromSeconds(60);
+                }
+
+                await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!success)
+            {
+                return new RootObject();
+            }
+
+            if (string.IsNullOrWhiteSpace(responseBody))
+            {
+                return new RootObject();
+            }
+
+            RootObject result = JsonSerializer.Deserialize<RootObject>(responseBody);
+
+            if (result is null)
+            {
+                return new RootObject();
+            }
+
+            return result;
         }
 
         private async Task WaitForRateLimit(CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -24,7 +24,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
     {
         private const string BaseApiUrl = "https://graphql.anilist.co/";
         private static readonly SemaphoreSlim _rateLimitLock = new(1, 1);
-        private static DateTimeOffset _nextRequestAt = DateTimeOffset.MinValue;
+        private static DateTimeOffset _lastRequestAt = DateTimeOffset.MinValue;
         private readonly ILogger _logger;
 
         private const string SearchAnimeGraphqlQuery = """
@@ -320,39 +320,62 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             var requestBody = JsonSerializer.Serialize(request);
             string responseBody = null;
             bool success = false;
+            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
+            var delayBetweenRequests = requestsPerMinute > 0 ?
+                TimeSpan.FromMinutes(1d / requestsPerMinute) :
+                TimeSpan.Zero;
 
-            for (var attempt = 0; attempt < 2; attempt++)
+            await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
             {
-                await WaitForRateLimit(cancellationToken).ConfigureAwait(false);
-
-                using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
-                responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                success = response.IsSuccessStatusCode;
-
-                if (success ||
-                    response.StatusCode != HttpStatusCode.TooManyRequests)
+                for (var attempt = 0; attempt < 2; attempt++)
                 {
-                    break;
-                }
+                    if (delayBetweenRequests > TimeSpan.Zero &&
+                        _lastRequestAt > DateTimeOffset.MinValue)
+                    {
+                        var rateLimitDelay = delayBetweenRequests - (DateTimeOffset.UtcNow - _lastRequestAt);
+                        if (rateLimitDelay > TimeSpan.Zero)
+                        {
+                            _logger?.LogInformation("Waiting {Delay} seconds for rate limit.", rateLimitDelay.TotalSeconds);
+                            await Task.Delay(rateLimitDelay, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
 
-                var delay = response.Headers.RetryAfter?.Delta;
-                if (delay is null &&
-                    response.Headers.RetryAfter?.Date is { } retryAfterDate)
-                {
-                    delay = retryAfterDate - DateTimeOffset.UtcNow;
-                }
+                    _lastRequestAt = DateTimeOffset.UtcNow;
+                    using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                    using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
+                    responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                    success = response.IsSuccessStatusCode;
 
-                var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
-                if (retryDelay <= TimeSpan.Zero)
-                {
-                    // If the Retry-After header is missing or invalid, default to a 60 second delay
-                    retryDelay = TimeSpan.FromSeconds(60);
-                }
+                    if (success ||
+                        response.StatusCode != HttpStatusCode.TooManyRequests)
+                    {
+                        break;
+                    }
 
-                await SetNextRequestAfter(retryDelay, cancellationToken).ConfigureAwait(false);
-                _logger?.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} seconds.", retryDelay.TotalSeconds);
-                await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                    // Got HTTP 429 response
+                    var delay = response.Headers.RetryAfter?.Delta;
+                    if (delay is null &&
+                        response.Headers.RetryAfter?.Date is { } retryAfterDate)
+                    {
+                        delay = retryAfterDate - DateTimeOffset.UtcNow;
+                    }
+
+                    var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
+                    if (retryDelay <= TimeSpan.Zero)
+                    {
+                        // If the Retry-After header is missing or invalid, default to a 60 second delay
+                        retryDelay = TimeSpan.FromSeconds(60);
+                    }
+
+                    _logger?.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} seconds.", retryDelay.TotalSeconds);
+                    await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                _rateLimitLock.Release();
             }
 
             if (!success)
@@ -373,54 +396,6 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             }
 
             return result;
-        }
-
-        private async Task WaitForRateLimit(CancellationToken cancellationToken)
-        {
-            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
-            if (requestsPerMinute <= 0)
-            {
-                return;
-            }
-
-            var delayBetweenRequests = TimeSpan.FromMinutes(1d / requestsPerMinute);
-            await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-            try
-            {
-                var now = DateTimeOffset.UtcNow;
-                if (_nextRequestAt > now)
-                {
-                    var delay = _nextRequestAt - now;
-                    _logger?.LogInformation("Waiting {Delay} seconds for rate limit.", delay.TotalSeconds);
-                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                    now = DateTimeOffset.UtcNow;
-                }
-
-                _nextRequestAt = now + delayBetweenRequests;
-            }
-            finally
-            {
-                _rateLimitLock.Release();
-            }
-        }
-
-        private static async Task SetNextRequestAfter(TimeSpan delay, CancellationToken cancellationToken)
-        {
-            await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-            try
-            {
-                var retryAfter = DateTimeOffset.UtcNow + delay;
-                if (_nextRequestAt < retryAfter)
-                {
-                    _nextRequestAt = retryAfter;
-                }
-            }
-            finally
-            {
-                _rateLimitLock.Release();
-            }
         }
     }
 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -319,66 +319,74 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         {
             var httpClient = Plugin.Instance.GetHttpClient();
             var requestBody = JsonSerializer.Serialize(request);
-            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
-            var delayBetweenRequests = requestsPerMinute > 0 ?
-                TimeSpan.FromMinutes(1d / requestsPerMinute) :
-                TimeSpan.Zero;
 
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                await WaitForConfiguredRateLimit(cancellationToken).ConfigureAwait(false);
+
+                using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
+
+                if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    var retryDelay = GetRateLimitRetryDelay(response);
+                    _logger.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", retryDelay.TotalMilliseconds);
+                    await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                    continue; // Retry one more time after the HTTP 429 delay
+                }
+
+                using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync<RootObject>(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            _logger.LogWarning("Failed to make request to AniList API after retrying due to rate limits. Giving up.");
+            return null;
+        }
+
+        private async Task WaitForConfiguredRateLimit(CancellationToken cancellationToken)
+        {
+            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
+            if (requestsPerMinute <= 0)
+            {
+                return;
+            }
+
+            var delayBetweenRequests = TimeSpan.FromMinutes(1d / requestsPerMinute);
             await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
-                for (var attempt = 0; attempt < 2; attempt++)
+                if (_lastRequestAt > DateTimeOffset.MinValue)
                 {
-                    if (delayBetweenRequests > TimeSpan.Zero &&
-                        _lastRequestAt > DateTimeOffset.MinValue)
+                    var rateLimitDelay = delayBetweenRequests - (DateTimeOffset.UtcNow - _lastRequestAt);
+                    if (rateLimitDelay > TimeSpan.Zero)
                     {
-                        var rateLimitDelay = delayBetweenRequests - (DateTimeOffset.UtcNow - _lastRequestAt);
-                        if (rateLimitDelay > TimeSpan.Zero)
-                        {
-                            _logger.LogInformation("Waiting {Delay} ms for rate limit.", rateLimitDelay.TotalMilliseconds);
-                            await Task.Delay(rateLimitDelay, cancellationToken).ConfigureAwait(false);
-                        }
+                        _logger.LogInformation("Waiting {Delay} ms for rate limit.", rateLimitDelay.TotalMilliseconds);
+                        await Task.Delay(rateLimitDelay, cancellationToken).ConfigureAwait(false);
                     }
-
-                    _lastRequestAt = DateTimeOffset.UtcNow;
-                    using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                    using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
-                    var responseBody = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-
-                    if (response.IsSuccessStatusCode ||
-                        response.StatusCode != HttpStatusCode.TooManyRequests)
-                    {
-                        return await JsonSerializer.DeserializeAsync<RootObject>(responseBody, cancellationToken: cancellationToken).ConfigureAwait(false);
-                    }
-
-                    // Got HTTP 429 response
-                    var delay = response.Headers.RetryAfter?.Delta;
-                    if (delay is null &&
-                        response.Headers.RetryAfter?.Date is { } retryAfterDate)
-                    {
-                        delay = retryAfterDate - DateTimeOffset.UtcNow;
-                    }
-
-                    var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
-                    if (retryDelay <= TimeSpan.Zero)
-                    {
-                        // If the Retry-After header is missing or invalid, default to a 60 second delay
-                        retryDelay = TimeSpan.FromSeconds(60);
-                    }
-
-                    _logger.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", retryDelay.TotalMilliseconds);
-                    await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
                 }
 
-                // Still getting 429 after retrying, give up
-                _logger.LogWarning("Failed to make request to AniList API after retrying due to rate limits. Giving up.");
-                return null;
+                _lastRequestAt = DateTimeOffset.UtcNow;
             }
             finally
             {
                 _rateLimitLock.Release();
             }
+        }
+
+        private static TimeSpan GetRateLimitRetryDelay(HttpResponseMessage response)
+        {
+            var delay = response.Headers.RetryAfter?.Delta;
+            if (delay is null &&
+                response.Headers.RetryAfter?.Date is { } retryAfterDate)
+            {
+                delay = retryAfterDate - DateTimeOffset.UtcNow;
+            }
+
+            var retryDelay = delay ?? TimeSpan.Zero;
+            return retryDelay > TimeSpan.Zero ?
+                retryDelay :
+                TimeSpan.FromSeconds(60); // Fallback to 60 seconds if not supplied
         }
     }
 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -8,14 +8,10 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
-using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using Jellyfin.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Polly;
-using Polly.RateLimiting;
-using Polly.Retry;
 
 namespace Jellyfin.Plugin.AniList.Providers.AniList
 {
@@ -28,8 +24,8 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
     public class AniListApi
     {
         private const string BaseApiUrl = "https://graphql.anilist.co/";
-        private static readonly Lazy<TokenBucketRateLimiter> _rateLimiter =
-            new(CreateRateLimiter, LazyThreadSafetyMode.ExecutionAndPublication);
+        private static readonly SemaphoreSlim _rateLimitLock = new(1, 1);
+        private static DateTimeOffset _lastRequestAt = DateTimeOffset.MinValue;
         private readonly ILogger _logger;
 
         private const string SearchAnimeGraphqlQuery = """
@@ -323,94 +319,66 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         {
             var httpClient = Plugin.Instance.GetHttpClient();
             var requestBody = JsonSerializer.Serialize(request);
-            using var response = await CreatePipeline().ExecuteAsync(
-                async ct =>
-                {
-                    using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                    return await httpClient.PostAsync(BaseApiUrl, content, ct).ConfigureAwait(false);
-                },
-                cancellationToken
-            ).ConfigureAwait(false);
+            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
+            var delayBetweenRequests = requestsPerMinute > 0 ?
+                TimeSpan.FromMinutes(1d / requestsPerMinute) :
+                TimeSpan.Zero;
 
-            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
             {
+                for (var attempt = 0; attempt < 2; attempt++)
+                {
+                    if (delayBetweenRequests > TimeSpan.Zero &&
+                        _lastRequestAt > DateTimeOffset.MinValue)
+                    {
+                        var rateLimitDelay = delayBetweenRequests - (DateTimeOffset.UtcNow - _lastRequestAt);
+                        if (rateLimitDelay > TimeSpan.Zero)
+                        {
+                            _logger.LogInformation("Waiting {Delay} ms for rate limit.", rateLimitDelay.TotalMilliseconds);
+                            await Task.Delay(rateLimitDelay, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+
+                    _lastRequestAt = DateTimeOffset.UtcNow;
+                    using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
+                    using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
+                    var responseBody = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (response.IsSuccessStatusCode ||
+                        response.StatusCode != HttpStatusCode.TooManyRequests)
+                    {
+                        return await JsonSerializer.DeserializeAsync<RootObject>(responseBody, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // Got HTTP 429 response
+                    var delay = response.Headers.RetryAfter?.Delta;
+                    if (delay is null &&
+                        response.Headers.RetryAfter?.Date is { } retryAfterDate)
+                    {
+                        delay = retryAfterDate - DateTimeOffset.UtcNow;
+                    }
+
+                    var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
+                    if (retryDelay <= TimeSpan.Zero)
+                    {
+                        // If the Retry-After header is missing or invalid, default to a 60 second delay
+                        retryDelay = TimeSpan.FromSeconds(60);
+                    }
+
+                    _logger.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", retryDelay.TotalMilliseconds);
+                    await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Still getting 429 after retrying, give up
                 _logger.LogWarning("Failed to make request to AniList API after retrying due to rate limits. Giving up.");
                 return null;
             }
-
-            using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            return await JsonSerializer.DeserializeAsync<RootObject>(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
-        private ResiliencePipeline<HttpResponseMessage> CreatePipeline()
-        {
-            var builder = new ResiliencePipelineBuilder<HttpResponseMessage>()
-                .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
-                {
-                    // Handle HTTP 429 once
-                    ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(response =>
-                        response.StatusCode == HttpStatusCode.TooManyRequests),
-                    MaxRetryAttempts = 1,
-                    DelayGenerator = args => new ValueTask<TimeSpan?>(GetRetryDelay(args.Outcome.Result)),
-                    OnRetry = args =>
-                    {
-                        args.Outcome.Result?.Dispose();
-                        _logger.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", args.RetryDelay.TotalMilliseconds);
-                        return default;
-                    },
-                });
-
-            var rateLimiter = GetRateLimiter();
-            if (rateLimiter is not null)
+            finally
             {
-                builder.AddRateLimiter(rateLimiter);
+                _rateLimitLock.Release();
             }
-
-            return builder.Build();
-        }
-
-        private static TimeSpan GetRetryDelay(HttpResponseMessage response)
-        {
-            var delay = response.Headers.RetryAfter?.Delta;
-            if (delay is null &&
-                response.Headers.RetryAfter?.Date is { } retryAfterDate)
-            {
-                delay = retryAfterDate - DateTimeOffset.UtcNow;
-            }
-
-            var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
-            if (retryDelay <= TimeSpan.Zero)
-            {
-                retryDelay = TimeSpan.FromSeconds(60);
-            }
-
-            return retryDelay;
-        }
-
-        private static TokenBucketRateLimiter GetRateLimiter()
-        {
-            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
-            if (requestsPerMinute <= 0)
-            {
-                return null;
-            }
-
-            return _rateLimiter.Value;
-        }
-
-        private static TokenBucketRateLimiter CreateRateLimiter()
-        {
-            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
-            return new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
-            {
-                // Evenly spaced requests instead of bursty
-                AutoReplenishment = true,
-                QueueLimit = int.MaxValue,
-                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                ReplenishmentPeriod = TimeSpan.FromMinutes(1d / requestsPerMinute),
-                TokenLimit = 1,
-                TokensPerPeriod = 1,
-            });
         }
     }
 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -8,10 +8,14 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
+using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using Jellyfin.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Polly;
+using Polly.RateLimiting;
+using Polly.Retry;
 
 namespace Jellyfin.Plugin.AniList.Providers.AniList
 {
@@ -24,8 +28,8 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
     public class AniListApi
     {
         private const string BaseApiUrl = "https://graphql.anilist.co/";
-        private static readonly SemaphoreSlim _rateLimitLock = new(1, 1);
-        private static DateTimeOffset _lastRequestAt = DateTimeOffset.MinValue;
+        private static readonly Lazy<TokenBucketRateLimiter> _rateLimiter =
+            new(CreateRateLimiter, LazyThreadSafetyMode.ExecutionAndPublication);
         private readonly ILogger _logger;
 
         private const string SearchAnimeGraphqlQuery = """
@@ -319,66 +323,94 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         {
             var httpClient = Plugin.Instance.GetHttpClient();
             var requestBody = JsonSerializer.Serialize(request);
-            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
-            var delayBetweenRequests = requestsPerMinute > 0 ?
-                TimeSpan.FromMinutes(1d / requestsPerMinute) :
-                TimeSpan.Zero;
-
-            await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-            try
-            {
-                for (var attempt = 0; attempt < 2; attempt++)
+            using var response = await CreatePipeline().ExecuteAsync(
+                async ct =>
                 {
-                    if (delayBetweenRequests > TimeSpan.Zero &&
-                        _lastRequestAt > DateTimeOffset.MinValue)
-                    {
-                        var rateLimitDelay = delayBetweenRequests - (DateTimeOffset.UtcNow - _lastRequestAt);
-                        if (rateLimitDelay > TimeSpan.Zero)
-                        {
-                            _logger.LogInformation("Waiting {Delay} ms for rate limit.", rateLimitDelay.TotalMilliseconds);
-                            await Task.Delay(rateLimitDelay, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-
-                    _lastRequestAt = DateTimeOffset.UtcNow;
                     using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
-                    using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
-                    var responseBody = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                    return await httpClient.PostAsync(BaseApiUrl, content, ct).ConfigureAwait(false);
+                },
+                cancellationToken
+            ).ConfigureAwait(false);
 
-                    if (response.IsSuccessStatusCode ||
-                        response.StatusCode != HttpStatusCode.TooManyRequests)
-                    {
-                        return await JsonSerializer.DeserializeAsync<RootObject>(responseBody, cancellationToken: cancellationToken).ConfigureAwait(false);
-                    }
-
-                    // Got HTTP 429 response
-                    var delay = response.Headers.RetryAfter?.Delta;
-                    if (delay is null &&
-                        response.Headers.RetryAfter?.Date is { } retryAfterDate)
-                    {
-                        delay = retryAfterDate - DateTimeOffset.UtcNow;
-                    }
-
-                    var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
-                    if (retryDelay <= TimeSpan.Zero)
-                    {
-                        // If the Retry-After header is missing or invalid, default to a 60 second delay
-                        retryDelay = TimeSpan.FromSeconds(60);
-                    }
-
-                    _logger.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", retryDelay.TotalMilliseconds);
-                    await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
-                }
-
-                // Still getting 429 after retrying, give up
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
                 _logger.LogWarning("Failed to make request to AniList API after retrying due to rate limits. Giving up.");
                 return null;
             }
-            finally
+
+            using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<RootObject>(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        private ResiliencePipeline<HttpResponseMessage> CreatePipeline()
+        {
+            var builder = new ResiliencePipelineBuilder<HttpResponseMessage>()
+                .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+                {
+                    // Handle HTTP 429 once
+                    ShouldHandle = new PredicateBuilder<HttpResponseMessage>().HandleResult(response =>
+                        response.StatusCode == HttpStatusCode.TooManyRequests),
+                    MaxRetryAttempts = 1,
+                    DelayGenerator = args => new ValueTask<TimeSpan?>(GetRetryDelay(args.Outcome.Result)),
+                    OnRetry = args =>
+                    {
+                        args.Outcome.Result?.Dispose();
+                        _logger.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", args.RetryDelay.TotalMilliseconds);
+                        return default;
+                    },
+                });
+
+            var rateLimiter = GetRateLimiter();
+            if (rateLimiter is not null)
             {
-                _rateLimitLock.Release();
+                builder.AddRateLimiter(rateLimiter);
             }
+
+            return builder.Build();
+        }
+
+        private static TimeSpan GetRetryDelay(HttpResponseMessage response)
+        {
+            var delay = response.Headers.RetryAfter?.Delta;
+            if (delay is null &&
+                response.Headers.RetryAfter?.Date is { } retryAfterDate)
+            {
+                delay = retryAfterDate - DateTimeOffset.UtcNow;
+            }
+
+            var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
+            if (retryDelay <= TimeSpan.Zero)
+            {
+                retryDelay = TimeSpan.FromSeconds(60);
+            }
+
+            return retryDelay;
+        }
+
+        private static TokenBucketRateLimiter GetRateLimiter()
+        {
+            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
+            if (requestsPerMinute <= 0)
+            {
+                return null;
+            }
+
+            return _rateLimiter.Value;
+        }
+
+        private static TokenBucketRateLimiter CreateRateLimiter()
+        {
+            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
+            return new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                // Evenly spaced requests instead of bursty
+                AutoReplenishment = true,
+                QueueLimit = int.MaxValue,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                ReplenishmentPeriod = TimeSpan.FromMinutes(1d / requestsPerMinute),
+                TokenLimit = 1,
+                TokensPerPeriod = 1,
+            });
         }
     }
 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Jellyfin.Plugin.AniList.Providers.AniList
 {
@@ -210,7 +211,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
 
         public AniListApi(ILogger logger = null)
         {
-            _logger = logger;
+            _logger = logger ?? NullLogger.Instance;
         }
 
         /// <summary>
@@ -318,8 +319,6 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         {
             var httpClient = Plugin.Instance.GetHttpClient();
             var requestBody = JsonSerializer.Serialize(request);
-            string responseBody = null;
-            bool success = false;
             var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
             var delayBetweenRequests = requestsPerMinute > 0 ?
                 TimeSpan.FromMinutes(1d / requestsPerMinute) :
@@ -337,7 +336,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                         var rateLimitDelay = delayBetweenRequests - (DateTimeOffset.UtcNow - _lastRequestAt);
                         if (rateLimitDelay > TimeSpan.Zero)
                         {
-                            _logger?.LogInformation("Waiting {Delay} ms for rate limit.", rateLimitDelay.TotalMilliseconds);
+                            _logger.LogInformation("Waiting {Delay} ms for rate limit.", rateLimitDelay.TotalMilliseconds);
                             await Task.Delay(rateLimitDelay, cancellationToken).ConfigureAwait(false);
                         }
                     }
@@ -345,13 +344,12 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                     _lastRequestAt = DateTimeOffset.UtcNow;
                     using HttpContent content = new StringContent(requestBody, Encoding.UTF8, "application/json");
                     using var response = await httpClient.PostAsync(BaseApiUrl, content, cancellationToken).ConfigureAwait(false);
-                    responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                    success = response.IsSuccessStatusCode;
+                    var responseBody = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
-                    if (success ||
+                    if (response.IsSuccessStatusCode ||
                         response.StatusCode != HttpStatusCode.TooManyRequests)
                     {
-                        break;
+                        return await JsonSerializer.DeserializeAsync<RootObject>(responseBody, cancellationToken: cancellationToken).ConfigureAwait(false);
                     }
 
                     // Got HTTP 429 response
@@ -369,33 +367,18 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                         retryDelay = TimeSpan.FromSeconds(60);
                     }
 
-                    _logger?.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", retryDelay.TotalMilliseconds);
+                    _logger.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", retryDelay.TotalMilliseconds);
                     await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
                 }
+
+                // Still getting 429 after retrying, give up
+                _logger.LogWarning("Failed to make request to AniList API after retrying due to rate limits. Giving up.");
+                return null;
             }
             finally
             {
                 _rateLimitLock.Release();
             }
-
-            if (!success)
-            {
-                return new RootObject();
-            }
-
-            if (string.IsNullOrWhiteSpace(responseBody))
-            {
-                return new RootObject();
-            }
-
-            RootObject result = JsonSerializer.Deserialize<RootObject>(responseBody);
-
-            if (result is null)
-            {
-                return new RootObject();
-            }
-
-            return result;
         }
     }
 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -14,6 +14,7 @@ using Jellyfin.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly;
+using Polly.RateLimiting;
 using Polly.Retry;
 
 namespace Jellyfin.Plugin.AniList.Providers.AniList
@@ -27,9 +28,8 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
     public class AniListApi
     {
         private const string BaseApiUrl = "https://graphql.anilist.co/";
-        private static readonly object _rateLimiterLock = new();
-        private static TokenBucketRateLimiter _rateLimiter;
-        private static int _rateLimiterRequestsPerMinute;
+        private static readonly Lazy<TokenBucketRateLimiter> _rateLimiter =
+            new(CreateRateLimiter, LazyThreadSafetyMode.ExecutionAndPublication);
         private readonly ILogger _logger;
 
         private const string SearchAnimeGraphqlQuery = """
@@ -375,14 +375,12 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             if (delay is null &&
                 response.Headers.RetryAfter?.Date is { } retryAfterDate)
             {
-                // Use the Retry-After date header
                 delay = retryAfterDate - DateTimeOffset.UtcNow;
             }
 
-            var retryDelay = delay ?? TimeSpan.Zero;
+            var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
             if (retryDelay <= TimeSpan.Zero)
             {
-                // Default to 60 seconds if the header is missing
                 retryDelay = TimeSpan.FromSeconds(60);
             }
 
@@ -394,27 +392,15 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
             if (requestsPerMinute <= 0)
             {
-                // Rate limiting disabled
                 return null;
             }
 
-            lock (_rateLimiterLock)
-            {
-                if (_rateLimiter is not null &&
-                    _rateLimiterRequestsPerMinute == requestsPerMinute)
-                {
-                    return _rateLimiter;
-                }
-
-                // Rate limit configuration has changed, create a new rate limiter
-                _rateLimiterRequestsPerMinute = requestsPerMinute;
-                _rateLimiter = CreateRateLimiter(requestsPerMinute);
-                return _rateLimiter;
-            }
+            return _rateLimiter.Value;
         }
 
-        private static TokenBucketRateLimiter CreateRateLimiter(int requestsPerMinute)
+        private static TokenBucketRateLimiter CreateRateLimiter()
         {
+            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
             return new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
                 // Evenly spaced requests instead of bursty

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -20,6 +21,8 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
     public class AniListApi
     {
         private const string BaseApiUrl = "https://graphql.anilist.co/";
+        private static readonly SemaphoreSlim _rateLimitLock = new(1, 1);
+        private static DateTimeOffset _nextRequestAt = DateTimeOffset.MinValue;
 
         private const string SearchAnimeGraphqlQuery = """
             query ($query: String) {
@@ -305,6 +308,8 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         /// <returns></returns>
         private async Task<RootObject> WebRequestAPI(GraphQlRequest request, CancellationToken cancellationToken)
         {
+            await WaitForRateLimit(cancellationToken).ConfigureAwait(false);
+
             var httpClient = Plugin.Instance.GetHttpClient();
 
             using HttpContent content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
@@ -312,6 +317,35 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
             return await JsonSerializer.DeserializeAsync<RootObject>(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WaitForRateLimit(CancellationToken cancellationToken)
+        {
+            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
+            if (requestsPerMinute <= 0)
+            {
+                return;
+            }
+
+            var delayBetweenRequests = TimeSpan.FromMinutes(1d / requestsPerMinute);
+            await _rateLimitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                var now = DateTimeOffset.UtcNow;
+                if (_nextRequestAt > now)
+                {
+                    var delay = _nextRequestAt - now;
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                    now = DateTimeOffset.UtcNow;
+                }
+
+                _nextRequestAt = now + delayBetweenRequests;
+            }
+            finally
+            {
+                _rateLimitLock.Release();
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.AniList.Providers.AniList
 {
@@ -24,6 +25,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         private const string BaseApiUrl = "https://graphql.anilist.co/";
         private static readonly SemaphoreSlim _rateLimitLock = new(1, 1);
         private static DateTimeOffset _nextRequestAt = DateTimeOffset.MinValue;
+        private readonly ILogger _logger;
 
         private const string SearchAnimeGraphqlQuery = """
             query ($query: String) {
@@ -206,6 +208,11 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             public Dictionary<string, string> Variables { get; set; }
         }
 
+        public AniListApi(ILogger logger = null)
+        {
+            _logger = logger;
+        }
+
         /// <summary>
         /// API call to get the anime with the given id
         /// </summary>
@@ -343,6 +350,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                     retryDelay = TimeSpan.FromSeconds(60);
                 }
 
+                _logger?.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} seconds.", retryDelay.TotalSeconds);
                 await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
             }
 
@@ -383,6 +391,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                 if (_nextRequestAt > now)
                 {
                     var delay = _nextRequestAt - now;
+                    _logger?.LogInformation("Waiting {Delay} seconds for rate limit.", delay.TotalSeconds);
                     await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                     now = DateTimeOffset.UtcNow;
                 }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -337,7 +337,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                         var rateLimitDelay = delayBetweenRequests - (DateTimeOffset.UtcNow - _lastRequestAt);
                         if (rateLimitDelay > TimeSpan.Zero)
                         {
-                            _logger?.LogInformation("Waiting {Delay} seconds for rate limit.", rateLimitDelay.TotalSeconds);
+                            _logger?.LogInformation("Waiting {Delay} ms for rate limit.", rateLimitDelay.TotalMilliseconds);
                             await Task.Delay(rateLimitDelay, cancellationToken).ConfigureAwait(false);
                         }
                     }
@@ -369,7 +369,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
                         retryDelay = TimeSpan.FromSeconds(60);
                     }
 
-                    _logger?.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} seconds.", retryDelay.TotalSeconds);
+                    _logger?.LogInformation("Rate limited by AniList API. Retrying after {RetryDelay} ms.", retryDelay.TotalMilliseconds);
                     await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListApi.cs
@@ -14,7 +14,6 @@ using Jellyfin.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly;
-using Polly.RateLimiting;
 using Polly.Retry;
 
 namespace Jellyfin.Plugin.AniList.Providers.AniList
@@ -28,8 +27,9 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
     public class AniListApi
     {
         private const string BaseApiUrl = "https://graphql.anilist.co/";
-        private static readonly Lazy<TokenBucketRateLimiter> _rateLimiter =
-            new(CreateRateLimiter, LazyThreadSafetyMode.ExecutionAndPublication);
+        private static readonly object _rateLimiterLock = new();
+        private static TokenBucketRateLimiter _rateLimiter;
+        private static int _rateLimiterRequestsPerMinute;
         private readonly ILogger _logger;
 
         private const string SearchAnimeGraphqlQuery = """
@@ -375,12 +375,14 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             if (delay is null &&
                 response.Headers.RetryAfter?.Date is { } retryAfterDate)
             {
+                // Use the Retry-After date header
                 delay = retryAfterDate - DateTimeOffset.UtcNow;
             }
 
-            var retryDelay = delay.GetValueOrDefault(TimeSpan.FromSeconds(60));
+            var retryDelay = delay ?? TimeSpan.Zero;
             if (retryDelay <= TimeSpan.Zero)
             {
+                // Default to 60 seconds if the header is missing
                 retryDelay = TimeSpan.FromSeconds(60);
             }
 
@@ -392,15 +394,27 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
             var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
             if (requestsPerMinute <= 0)
             {
+                // Rate limiting disabled
                 return null;
             }
 
-            return _rateLimiter.Value;
+            lock (_rateLimiterLock)
+            {
+                if (_rateLimiter is not null &&
+                    _rateLimiterRequestsPerMinute == requestsPerMinute)
+                {
+                    return _rateLimiter;
+                }
+
+                // Rate limit configuration has changed, create a new rate limiter
+                _rateLimiterRequestsPerMinute = requestsPerMinute;
+                _rateLimiter = CreateRateLimiter(requestsPerMinute);
+                return _rateLimiter;
+            }
         }
 
-        private static TokenBucketRateLimiter CreateRateLimiter()
+        private static TokenBucketRateLimiter CreateRateLimiter(int requestsPerMinute)
         {
-            var requestsPerMinute = Plugin.Instance.Configuration.AniDbRateLimit;
             return new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
                 // Evenly spaced requests instead of bursty

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListMovieProvider.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListMovieProvider.cs
@@ -22,7 +22,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         public AniListMovieProvider(ILogger<AniListMovieProvider> logger)
         {
             _log = logger;
-            _aniListApi = new AniListApi();
+            _aniListApi = new AniListApi(logger);
         }
 
         public async Task<MetadataResult<Movie>> GetMetadata(MovieInfo info, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.AniList/Providers/AniList/AniListSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniList/Providers/AniList/AniListSeriesProvider.cs
@@ -22,7 +22,7 @@ namespace Jellyfin.Plugin.AniList.Providers.AniList
         public AniListSeriesProvider(ILogger<AniListSeriesProvider> logger)
         {
             _log = logger;
-            _aniListApi = new AniListApi();
+            _aniListApi = new AniListApi(logger);
         }
 
         public async Task<MetadataResult<Series>> GetMetadata(SeriesInfo info, CancellationToken cancellationToken)


### PR DESCRIPTION
currently anilist blocks jellyfin user-agent because apparently we dont have a working rate limiter. this pr is a simplified version of #79. 

this pr makes sure all requests will wait for at least `60 / AniDbRateLimit` seconds. for example, with rate limit value set to 30, each request will wait at least for 2 seconds so in a minute it will never exceed 30 requests.

this pr also contains http 429 error handling in case their api changes the rate limit policy again. for now i set the default rate limit to be 30 requests per minute amid ongoing 'stability issues' their api is currently experiencing.

logs:

<img width="1027" height="626" alt="image" src="https://github.com/user-attachments/assets/ae982370-66b4-46ec-b696-63f2fbe4e9b6" />
